### PR TITLE
docs: title for "surely"

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,10 +464,11 @@ userName(function(error, something){
 
 ```
 
-## Surely (resolve [error?, results...?])
+## Surely
 
 You can resolve a task to an array containing either
-the error or results from a righto with `righto.surely`
+the error or results from a righto with `righto.surely`,
+which resolves to an array in the form of `[error?, results...?]`.
 
 ```javascript
 


### PR DESCRIPTION
- consistent with the other headings
- nicer URL for auto-generated anchor tags:
  was: https://github.com/KoryNunn/righto#surely-resolve-error-results
  now: https://github.com/KoryNunn/righto#surely